### PR TITLE
Prevent "Undefined variable: $size" error in line-height mixin.

### DIFF
--- a/stylesheets/typey/_line-height.scss
+++ b/stylesheets/typey/_line-height.scss
@@ -50,7 +50,7 @@
         line-height: $x * $base-line-height;
       }
       @if type-of($x) == "number" and not unitless($x) {
-        @if unit($size) == px {
+        @if unit($x) == px {
           line-height: $x;
         }
         @else {


### PR DESCRIPTION
In beta.4, when I use the line-height mixin, I'm seeing a fatal error:

```
error (Line 53 of ruby/1.9.1/gems/typey-1.0.0.beta.4/stylesheets/typey/_line-height.scss: Undefined variable: "$size".)
```
