### PR TITLE
define-type-sizing() outputs incorrect line-height with rem base-unit

### DIFF
--- a/stylesheets/typey/mixins/_define-type-sizing.scss
+++ b/stylesheets/typey/mixins/_define-type-sizing.scss
@@ -22,13 +22,9 @@
       line-height: $line-height;
     }
     @else {
-      @if $base-unit == rem {
-        @if $rem-fallback == true {
-          line-height: $line-height;
-        }
-      }
       @if $base-unit == rem or $base-unit == em {
-        line-height: typey-output-in-base-unit($line-height / $size);
+        // In the html element, rem means relative to browser default font size; em means relative to html's font size.
+        line-height: $line-height / $size * 1em;
       }
       @if $base-unit == px {
         line-height: $line-height;


### PR DESCRIPTION
In the html element, rem means relative to browser default font size; em means relative to html's font size.

So, if $base-unit is rem, the define-type-sizing() mixin outputs a line-height in rem, which is relative to the wrong font-size.
