### PR TITLE
Add compatibility with node-sass or eyeglass

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,16 +1,16 @@
 {
   "name"        : "typey",
-  "version"     : "1.0.0.beta.8",
   "homepage"    : "http://github.com/jptaranto/typey",
   "author"      : ["Jack Taranto"],
   "description" : "A complete framework for working with typography in sass.",
   "main"        : [
-    "_typey.scss"
+    "stylesheets/_typey.scss"
   ],
   "keywords"    : [
+    "sass",
     "typography"
   ],
-  "license"     : "GPLv2",
+  "license"     : "GPL-2.0",
   "ignore"      : [
     "typey.gemspec",
     "sache.json",

--- a/eyeglass-exports.js
+++ b/eyeglass-exports.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = function(eyeglass, sass) {
+  return {
+    sassDir: path.join(__dirname, 'stylesheets')
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "typey",
+  "version": "1.0.0-beta.8",
+  "description": "A complete framework for working with typography in sass.",
+  "main": "stylesheets/_typey.scss",
+  "directories": {
+    "lib": "stylesheets",
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jptaranto/typey.git"
+  },
+  "keywords": [
+    "sass",
+    "typography"
+  ],
+  "author": "jptaranto <jacktaranto@gmail.com>",
+  "license": "GPL-2.0",
+  "bugs": {
+    "url": "https://github.com/jptaranto/typey/issues"
+  },
+  "homepage": "https://github.com/jptaranto/typey#readme"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0-beta.8",
   "description": "A complete framework for working with typography in sass.",
   "main": "stylesheets/_typey.scss",
+  "eyeglass": {
+    "exports": "eyeglass-exports.js"
+  },
   "directories": {
     "lib": "stylesheets",
     "example": "examples"


### PR DESCRIPTION
In order to use Typey with node-sass, you need to be able to install it with npm. Which means you need to publish it on npmjs.org
1. Create an account at https://www.npmjs.com/signup
2. Log into your account from the command line with: `npm login`

Then for each new version of Typey, you'll need to:
1. **For Ruby gems** Edit `typey.gemspec` to update the version and date. Ruby can't use dashes in the version number which sucks. So the version format will have to be `1.0.0.beta.10`. Rubygem "standard" says any alphabetical character in the version number will indicate that the version is a pre-release.
2. **For npm** Edit `package.json` to update the version. Requires [semver](http://semver.org/) standard, which means dashes indicate a pre-release. `1.0.0-beta.10`
3. `git commit` the changes.
4. **For Bower** Make a git tag using the semver version. `git tag 1.0.0-beta.10`
5. `git push` and `git push --tags`
6. To publish everywhere:
   1. Push to npmjs.org with `npm publish`
   2. Push the gem to Rubygems.org with: `gem push typey-1.0.0.whatever.gem`
7. Rinse.
8. Repeat.
