### PR TITLE
Fix eyeglass integration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A complete framework for working with typography in sass.",
   "main": "stylesheets/_typey.scss",
   "eyeglass": {
-    "exports": "eyeglass-exports.js"
+    "exports": "eyeglass-exports.js",
+    "needs": "^0.7.1"
   },
   "directories": {
     "lib": "stylesheets",
@@ -18,6 +19,7 @@
     "url": "git+https://github.com/jptaranto/typey.git"
   },
   "keywords": [
+    "eyeglass-module",
     "sass",
     "typography"
   ],


### PR DESCRIPTION
Whoops! I messed up the eyeglass integration on my own npm modules. I've fixed them. And need to fix Typey too.

When you use [Eyeglass](https://github.com/sass-eyeglass/eyeglass) with node-sass, it will look in your local package.json to find any dependencies (like breakpoint or typey) and then look in each of those dependency's pacakge.json file for a "eyeglass-module" keyword. I don't know why it needs that flag, but if its not there, it won't look for the eyeglass-exports.js file at all. :-p
