### PR TITLE
Allow compatibility with any version of Eyeglass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "stylesheets/_typey.scss",
   "eyeglass": {
     "exports": "eyeglass-exports.js",
-    "needs": "^0.7.1"
+    "needs": "*"
   },
   "directories": {
     "lib": "stylesheets",


### PR DESCRIPTION
Eyeglass 0.8 was released with the same API as 0.7, but existing sass modules won't work with Eyeglass 0.8 until they update their `needs` line in package.json. :-p

This PR updates the `needs` line so that it ignores the version number of Eyeglass and will work with any future version.
