### PR TITLE
Add copyright as a "loud comment".

### DIFF
--- a/stylesheets/_typey.scss
+++ b/stylesheets/_typey.scss
@@ -1,3 +1,4 @@
+/*! typey | GPLv2 License | https://github.com/jptaranto/typey */
 @import "typey/functions/helpers";
 @import "typey/functions/validators";
 @import "typey/functions/em-calculators";


### PR DESCRIPTION
Similar to normalize-scss, add a loud comment stating library existence in output:

https://github.com/JohnAlbin/normalize-scss/blob/master/fork-versions/typey/_normalize.scss#L1

An additional tweak would be a shorter URL from your favorite shortener.