### PR TITLE
Revert "Add copyright as a "loud comment"."

### DIFF
--- a/stylesheets/_typey.scss
+++ b/stylesheets/_typey.scss
@@ -1,4 +1,3 @@
-/*! typey | GPLv2 License | https://github.com/jptaranto/typey */
 @import "typey/functions/helpers";
 @import "typey/functions/validators";
 @import "typey/functions/em-calculators";


### PR DESCRIPTION
I disagree with this PR: https://github.com/jptaranto/typey/pull/15

The normalize-scss file mentioned above copied its "loud comment" from normalize.css. Both that normalize-scss file and normalize.css are actual stylesheets; they include CSS rulesets with the comment. (If you think that normalize-scss stylesheet should not have a comment, I will happily remove it, btw.)

Normalize-scss also has a mixin that you can use. https://github.com/JohnAlbin/normalize-scss/tree/master/sass It does _not_ include a "loud comment" because it is a library. Node Sass does not include a `/*! Made with Node Sass */` comment in each CSS file that it creates and neither should Typey.